### PR TITLE
Add APIs & documentation to TextStyler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
+	modImplementation fabricApi.module("fabric-api-base", project.fabric_api_version)
+
 	include(implementation('org.commonmark:commonmark:0.18.1'))
 
 	include(implementation('org.commonmark:commonmark-ext-autolink:0.18.1'))

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 minecraft_version=1.18.2
 yarn_mappings=1.18.2+build.1
 loader_version=0.13.3
+fabric_api_version=0.47.9+1.18.2
 # Mod Properties
 mod_version=1.2.0
 maven_group=dev.gegy

--- a/src/main/java/dev/gegy/mdchat/BuiltinStylers.java
+++ b/src/main/java/dev/gegy/mdchat/BuiltinStylers.java
@@ -1,0 +1,136 @@
+package dev.gegy.mdchat;
+
+import dev.gegy.mdchat.parser.ColoredChatExtension;
+import dev.gegy.mdchat.parser.FormattedNode;
+import dev.gegy.mdchat.parser.SpoilerExtension;
+import dev.gegy.mdchat.parser.SpoilerNode;
+import net.minecraft.text.*;
+import net.minecraft.util.Formatting;
+import org.commonmark.ext.autolink.AutolinkExtension;
+import org.commonmark.ext.gfm.strikethrough.Strikethrough;
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
+import org.commonmark.node.Text;
+import org.commonmark.node.*;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class BuiltinStylers {
+	public static final NodeStyler LITERAL = (node, innerContent) -> {
+		if (node instanceof Text text) {
+			return new LiteralText(text.getLiteral());
+		}
+		return null;
+	};
+
+	public static final NodeStyler CODE = (node, innerContent) -> {
+		if (node instanceof Code code) {
+			String literal = code.getLiteral();
+			MutableText text = new LiteralText(literal).formatted(Formatting.GRAY);
+			if (literal.startsWith("/")) {
+				return text.styled(style -> style
+						.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText("Click to Copy to Console")))
+						.withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, literal))
+				);
+			} else {
+				return text.styled(style -> style
+						.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TranslatableText("chat.copy.click")))
+						.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, literal))
+				);
+			}
+		}
+		return null;
+	};
+
+	public static final NodeStyler BOLD = (node, innerContent) -> {
+		if (node instanceof StrongEmphasis emphasis && innerContent != null) {
+			String delimiter = emphasis.getOpeningDelimiter();
+			if (delimiter.equals("**")) {
+				return innerContent.formatted(Formatting.BOLD);
+			}
+		}
+		return null;
+	};
+
+	public static final NodeStyler UNDERLINE = (node, innerContent) -> {
+		if (node instanceof StrongEmphasis emphasis && innerContent != null) {
+			String delimiter = emphasis.getOpeningDelimiter();
+			if (delimiter.equals("__")) {
+				return innerContent.formatted(Formatting.UNDERLINE);
+			}
+		}
+		return null;
+	};
+
+	public static final NodeStyler ITALIC = (node, innerContent) -> {
+		if (node instanceof Emphasis && innerContent != null) {
+			return innerContent.formatted(Formatting.ITALIC);
+		}
+		return null;
+	};
+
+	public static final NodeStyler STRIKETHROUGH = (node, innerContent) -> {
+		if (node instanceof Strikethrough && innerContent != null) {
+			return innerContent.formatted(Formatting.STRIKETHROUGH);
+		}
+		return null;
+	};
+
+	public static final NodeStyler LINK = (node, innerContent) -> {
+		if (node instanceof Link link) {
+			MutableText title = Objects.requireNonNullElseGet(innerContent, () -> new LiteralText(link.getDestination()));
+
+			MutableText redirectsTo = new LiteralText("Goes to ")
+					.append(new LiteralText(link.getDestination()).formatted(Formatting.AQUA, Formatting.UNDERLINE))
+					.formatted(Formatting.GRAY, Formatting.ITALIC);
+
+			String hoverText = link.getTitle();
+			MutableText hover;
+			if (hoverText != null) {
+				hover = new LiteralText(hoverText).append("\n\n").append(redirectsTo);
+			} else {
+				hover = redirectsTo;
+			}
+
+			return title.setStyle(buildLinkStyle(link.getDestination(), hover));
+		}
+
+		return null;
+	};
+
+	public static final NodeStyler FORMATTED = (node, innerContent) -> {
+		if (node instanceof FormattedNode formatted && innerContent != null) {
+			return innerContent.formatted(formatted.getFormatting());
+		}
+		return null;
+	};
+
+	private static final Style SPOILER_STYLE = Style.EMPTY.withFormatting(Formatting.DARK_GRAY, Formatting.OBFUSCATED);
+
+	public static final NodeStyler SPOILER = (node, innerContent) -> {
+		if (node instanceof SpoilerNode && innerContent != null) {
+			return innerContent.shallowCopy()
+					.setStyle(SPOILER_STYLE.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, innerContent)));
+		}
+		return null;
+	};
+
+	private static Style buildLinkStyle(String url, MutableText hover) {
+		return Style.EMPTY
+				.withFormatting(Formatting.AQUA, Formatting.UNDERLINE)
+				.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url))
+				.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hover));
+	}
+
+	public static void addTo(TextStyler.Builder builder) {
+		NodeStyler styler = NodeStyler.compose(LITERAL, CODE, BOLD, UNDERLINE, ITALIC, STRIKETHROUGH, LINK, FORMATTED, SPOILER);
+		builder.addNodeStyler(styler);
+
+		builder.addExtensions(List.of(
+				ColoredChatExtension.INSTANCE,
+				SpoilerExtension.INSTANCE,
+				AutolinkExtension.create(),
+				StrikethroughExtension.create()
+		));
+	}
+}

--- a/src/main/java/dev/gegy/mdchat/NodeStyler.java
+++ b/src/main/java/dev/gegy/mdchat/NodeStyler.java
@@ -1,0 +1,39 @@
+package dev.gegy.mdchat;
+
+import net.minecraft.text.MutableText;
+import org.commonmark.node.Node;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Styles & formats nodes into Minecraft text nodes.
+ *
+ * @author KJP12
+ * @since 1.3.0
+ **/
+@FunctionalInterface
+public interface NodeStyler {
+    static NodeStyler compose(NodeStyler... stylers) {
+        return (node, innerContent) -> {
+            for (NodeStyler styler : stylers) {
+                MutableText text = styler.style(node, innerContent);
+                if (text != null) {
+                    return text;
+                }
+            }
+            return null;
+        };
+    }
+
+    /**
+     * Styles the given markdown node & formatted child text into Minecraft-formatted text.
+     *
+     * @param node The markdown node to format.
+     * @param innerContent The rendered text from the child nodes.
+     * @return If handled, a maybe formatted Minecraft text node, else null.
+     * @implNote It is possible for this method to be called off-thread. Ensure that the
+     * implementation is thread-safe (e.g. concurrent or read-only maps &amp; lists),
+     * and won't cause issues due to 2 calls occurring at once.
+     */
+    @Nullable
+    MutableText style(Node node, @Nullable MutableText innerContent);
+}

--- a/src/main/java/dev/gegy/mdchat/StylerBootstrap.java
+++ b/src/main/java/dev/gegy/mdchat/StylerBootstrap.java
@@ -1,0 +1,46 @@
+package dev.gegy.mdchat;// Created 2022-04-03T02:46:38
+
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.util.List;
+
+/**
+ * Bootstraps a {@link TextStyler} by building parser extensions and {@link NodeStyler node stylers} into a
+ * {@link TextStyler.Builder}.
+ * <p>
+ * Instances of this exposed as a Fabric entrypoint through the {@code markdown-chat} key will be called and run for
+ * the global {@link TextStyler#INSTANCE} styler, or any styler created through {@link TextStyler#builderWithGlobal()}.
+ *
+ * @author KJP12
+ * @since 1.3.0
+ **/
+@FunctionalInterface
+public interface StylerBootstrap {
+    static StylerBootstrap global() {
+        // We're using FabricLoader's entrypoint system here as it isn't possible to
+        // determine when we'll be bootstrapped as any mod can load this class at any time.
+        List<StylerBootstrap> bootstraps = FabricLoader.getInstance().getEntrypoints("markdown-chat", StylerBootstrap.class);
+
+        return styler -> {
+            BuiltinStylers.addTo(styler);
+            for (StylerBootstrap bootstrap : bootstraps) {
+                bootstrap.bootstrap(styler);
+            }
+        };
+    }
+
+    /**
+     * Bootstraps a {@link TextStyler}.
+     *
+     * @param styler The {@link TextStyler.Builder} to attach styling functionality to
+     * @implSpec This method is only called once per each instance of {@link TextStyler.Builder}.
+     *         It must not assume that the first invocation is the {@link TextStyler#INSTANCE} text styler,
+     *         and that each {@link TextStyler.Builder} given must be extended in the exact same way each
+     *         time when being implemented as the {@code markdown-chat} entrypoint in {@code fabric.mod.json}.
+     * @implNote It is possible for this method to be called off-thread. Ensure that the
+     *         implementation is thread-safe (e.g. concurrent or read-only maps &amp; lists),
+     *         and won't cause issues due to 2 calls occurring at once.
+     * @see TextStyler#builderWithGlobal()
+     */
+    void bootstrap(TextStyler.Builder styler);
+}

--- a/src/main/java/dev/gegy/mdchat/TextStyler.java
+++ b/src/main/java/dev/gegy/mdchat/TextStyler.java
@@ -1,165 +1,78 @@
 package dev.gegy.mdchat;
 
-import com.google.common.collect.Lists;
-import dev.gegy.mdchat.parser.ColoredChatExtension;
-import dev.gegy.mdchat.parser.FormattedNode;
-import dev.gegy.mdchat.parser.SpoilerExtension;
-import dev.gegy.mdchat.parser.SpoilerNode;
-import net.minecraft.text.*;
-import net.minecraft.util.Formatting;
-import org.commonmark.ext.autolink.AutolinkExtension;
-import org.commonmark.ext.gfm.strikethrough.Strikethrough;
-import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
-import org.commonmark.node.Text;
-import org.commonmark.node.*;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import org.commonmark.Extension;
+import org.commonmark.node.Block;
+import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
+import org.commonmark.parser.PostProcessor;
+import org.commonmark.parser.block.BlockParserFactory;
+import org.commonmark.parser.delimiter.DelimiterProcessor;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 public final class TextStyler {
-    public static final TextStyler INSTANCE = new TextStyler();
+    public static final TextStyler INSTANCE = builderWithGlobal().build();
 
-    private static final Style SPOILER = Style.EMPTY.withFormatting(Formatting.DARK_GRAY, Formatting.OBFUSCATED);
+    private final NodeStyler styler;
+    private final Parser parser;
 
-    private static final Parser PARSER = Parser.builder()
-            .enabledBlockTypes(Collections.emptySet())
-            .extensions(Lists.newArrayList(
-                    ColoredChatExtension.INSTANCE,
-                    SpoilerExtension.INSTANCE,
-                    AutolinkExtension.create(),
-                    StrikethroughExtension.create()
-            ))
-            .build();
-
-    private TextStyler() {
+    private TextStyler(NodeStyler styler, Parser parser) {
+        this.styler = styler;
+        this.parser = parser;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a new TextStyler based off of globally-invoked bootstraps.
+     *
+     * @return A global-like TextStyler.
+     * @author KJP12
+     * @since 1.3.0
+     */
+    public static TextStyler.Builder builderWithGlobal() {
+        TextStyler.Builder stylerBuilder = new TextStyler.Builder();
+        StylerBootstrap.global().bootstrap(stylerBuilder);
+
+        return stylerBuilder;
+    }
+
+    /**
+     * Converts the input string into formatted Minecraft text elements.
+     *
+     * @param string The input markdown string.
+     * @return Formatted Minecraft text.
+     */
     @Nullable
     public net.minecraft.text.Text apply(String string) {
-        Node node = PARSER.parse(string);
-        return this.renderAsText(node);
+        Node node = this.parser.parse(string);
+        return this.render(node);
     }
 
     @Nullable
-    private MutableText renderAsText(Node node) {
-        if (node instanceof Text) {
-            return this.renderLiteral((Text) node);
-        } else if (node instanceof Code) {
-            return this.renderCode((Code) node);
-        } else if (node instanceof StrongEmphasis) {
-            return this.renderStrongEmphasis((StrongEmphasis) node);
-        } else if (node instanceof Emphasis) {
-            return this.renderEmphasis(node, Formatting.ITALIC);
-        } else if (node instanceof Strikethrough) {
-            return this.renderEmphasis(node, Formatting.STRIKETHROUGH);
-        } else if (node instanceof Link) {
-            return this.renderLink((Link) node);
-        } else if (node instanceof FormattedNode) {
-            return this.renderFormattedText((FormattedNode) node);
-        } else if (node instanceof SpoilerNode) {
-            return this.renderSpoiler((SpoilerNode) node);
-        }
-
-        return this.renderChildren(node);
-    }
-
-    private MutableText renderLiteral(Text text) {
-        return new LiteralText(text.getLiteral());
-    }
-
-    private MutableText renderCode(Code code) {
-        String literal = code.getLiteral();
-        MutableText text = new LiteralText(literal).formatted(Formatting.GRAY);
-        if (literal.startsWith("/")) {
-            return text.styled(style -> style
-                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText("Click to Copy to Console")))
-                    .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, literal))
-            );
-        } else {
-            return text.styled(style -> style
-                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TranslatableText("chat.copy.click")))
-                    .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, literal))
-            );
-        }
-    }
-
-    private MutableText renderStrongEmphasis(StrongEmphasis emphasis) {
-        String delimiter = emphasis.getOpeningDelimiter();
-        if (delimiter.equals("__")) {
-            return this.renderEmphasis(emphasis, Formatting.UNDERLINE);
-        } else {
-            return this.renderEmphasis(emphasis, Formatting.BOLD);
-        }
+    private MutableText render(Node node) {
+        MutableText innerContent = this.renderInnerContent(node);
+        MutableText styledContent = this.styler.style(node, innerContent);
+        return styledContent != null ? styledContent : innerContent;
     }
 
     @Nullable
-    private MutableText renderFormattedText(FormattedNode formatted) {
-        MutableText text = this.renderChildren(formatted);
-        if (text != null) {
-            return text.formatted(formatted.getFormatting());
-        }
-        return null;
-    }
-
-    @Nullable
-    private MutableText renderSpoiler(SpoilerNode spoiler) {
-        MutableText text = this.renderChildren(spoiler);
-        if (text != null) {
-            return text.shallowCopy()
-                    .setStyle(SPOILER.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, text)));
-        }
-        return null;
-    }
-
-    @Nullable
-    private MutableText renderEmphasis(Node node, Formatting formatting) {
-        MutableText text = this.renderChildren(node);
-        if (text != null) {
-            return text.formatted(formatting);
-        }
-        return null;
-    }
-
-    @Nullable
-    private MutableText renderLink(Link link) {
-        MutableText title = this.renderChildren(link);
-
-        if (title == null) {
-            title = new LiteralText(link.getDestination());
-        }
-
-        MutableText redirectsTo = new LiteralText("Goes to ")
-                .append(new LiteralText(link.getDestination()).formatted(Formatting.AQUA, Formatting.UNDERLINE))
-                .formatted(Formatting.GRAY, Formatting.ITALIC);
-
-        String hoverText = link.getTitle();
-        MutableText hover;
-        if (hoverText != null) {
-            hover = new LiteralText(hoverText).append("\n\n").append(redirectsTo);
-        } else {
-            hover = redirectsTo;
-        }
-
-        return title.setStyle(this.buildLinkStyle(link.getDestination(), hover));
-    }
-
-    private Style buildLinkStyle(String url, MutableText hover) {
-        return Style.EMPTY
-                .withFormatting(Formatting.AQUA, Formatting.UNDERLINE)
-                .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url))
-                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hover));
-    }
-
-    @Nullable
-    private MutableText renderChildren(Node parent) {
+    private MutableText renderInnerContent(Node parent) {
         MutableText result = null;
 
         Node child = parent.getFirstChild();
         while (child != null) {
             Node next = child.getNext();
 
-            MutableText text = this.renderAsText(child);
+            MutableText text = this.render(child);
             if (text != null) {
                 if (result == null) {
                     result = new LiteralText("");
@@ -171,5 +84,56 @@ public final class TextStyler {
         }
 
         return result;
+    }
+
+    public static final class Builder {
+        private final List<NodeStyler> nodeStylers = new ArrayList<>();
+        private final Parser.Builder parser = Parser.builder();
+        private final Set<Class<? extends Block>> enabledBlockTypes = new ReferenceOpenHashSet<>();
+
+        private Builder() {
+        }
+
+        public void addNodeStyler(NodeStyler nodeStyler) {
+            this.nodeStylers.add(nodeStyler);
+        }
+
+        public Builder addExtension(Extension extension) {
+            return this.addExtensions(List.of(extension));
+        }
+
+        public Builder addExtensions(Iterable<? extends Extension> extensions) {
+            this.parser.extensions(extensions);
+            return this;
+        }
+
+        public Builder enableBlockType(Class<? extends Block> blockType) {
+            this.enabledBlockTypes.add(blockType);
+            return this;
+        }
+
+        public Builder addBlockParserFactory(BlockParserFactory blockParserFactory) {
+            this.parser.customBlockParserFactory(blockParserFactory);
+            return this;
+        }
+
+        public Builder addDelimiterProcessor(DelimiterProcessor delimiterProcessor) {
+            this.parser.customDelimiterProcessor(delimiterProcessor);
+            return this;
+        }
+
+        public Builder addPostProcessor(PostProcessor postProcessor) {
+            this.parser.postProcessor(postProcessor);
+            return this;
+        }
+
+        public TextStyler build() {
+            NodeStyler nodeStyler = NodeStyler.compose(this.nodeStylers.toArray(NodeStyler[]::new));
+            Parser parser = this.parser
+                    .enabledBlockTypes(this.enabledBlockTypes)
+                    .build();
+
+            return new TextStyler(nodeStyler, parser);
+        }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,6 +14,7 @@
   "accessWidener": "markdown_chat.accesswidener",
   "depends": {
     "minecraft": ">=1.17",
-    "java": ">=17"
+    "java": ">=17",
+    "fabric-api-base": "*"
   }
 }


### PR DESCRIPTION
Added APIs. Current (and only at time of PR) reference implementation is https://github.com/KJP12/DisFabric for use with parsing Discord's mentions, emotes & time tags. This is mostly to see how it'd fit in for other mods. Note, this only uses the global instance, and thus, uses the global bootstrap.

Things of note:
 - The since tags have been set to `1.3.0`.
 - The current entry point for `StylerBootstrap` is currently `markdown-chat` rather than `markdown_chat`, should that be changed?
 - The established API has not been changed, only extended.
 - There's still default fallback methods built into `TextStyler`.
   - Should that remain, or be moved out into its own `NodeStyler` implementation?
 - A `StylerBootstrap` implementation can also be provided directly into `TextStyler#ofGlobal` and `TextStyler#ofLocal` for making additional modifications.
 - There's a secondary `TextStyler#ofLocal` to allow for a completely custom implementation as well.